### PR TITLE
Feat: Validate inputs and outputs for size

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -85,5 +85,27 @@
 	"TrackingCategories": [
 		"tpt-tracking-category"
 	],
+    "config": {
+      "TableProgressTrackingMaxRows": {
+        "description": "Integer. Maximum amount of rows that will be parsed before returning an error.",
+        "value": "100"
+      },
+      "TableProgressTrackingMaxColumns": {
+        "description": "Integer. Maximum amount of columns that will be parsed before returning an error.",
+        "value": "10"
+      },
+      "TableProgressTrackingMaxHTMLSize": {
+        "description": "Integer. Parser will bail when the parsed HTML reaches this value. Set to 25% of $wgMaxArticleSize by default",
+        "value": null
+      },
+      "TableProgressTrackingMaxProcessingTime": {
+        "description": "Integer. Maximum number of seconds before the parser abandons parsing",
+        "value": 5
+      },
+      "TableProgressTrackingMaxWikitextSize": {
+        "description": "Integer. Maximum bytes of wikitext allowable for parsing. Default to 50KB",
+        "value": 50000
+      }
+    },
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -88,11 +88,11 @@
     "config": {
       "TableProgressTrackingMaxRows": {
         "description": "Integer. Maximum amount of rows that will be parsed before returning an error.",
-        "value": "100"
+        "value": 100
       },
       "TableProgressTrackingMaxColumns": {
         "description": "Integer. Maximum amount of columns that will be parsed before returning an error.",
-        "value": "10"
+        "value": 10
       },
       "TableProgressTrackingMaxHTMLSize": {
         "description": "Integer. Parser will bail when the parsed HTML reaches this value. Set to 25% of $wgMaxArticleSize by default",
@@ -102,7 +102,7 @@
         "description": "Integer. Maximum number of seconds before the parser abandons parsing",
         "value": 5
       },
-      "TableProgressTrackingMaxWikitextSize": {
+      "TableProgressTrackingMaxInputSize": {
         "description": "Integer. Maximum bytes of wikitext allowable for parsing. Default to 50KB",
         "value": 50000
       }

--- a/extension.json
+++ b/extension.json
@@ -107,5 +107,8 @@
         "value": 50000
       }
     },
+    "ConfigRegistry": {
+      "TableProgressTracking": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
+    },
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"descriptionmsg": "tableprogresstracking-desc",
 	"license-name": "Apache-2.0",
 	"type": "parserhook",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"requires": {
 		"MediaWiki": ">= 1.43.0"
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,5 +6,11 @@
 	},
     "tableprogresstracking-desc": "An extension to track progress against MediaWiki tables.",
     "tableprogresstracking-duplicate-tables": "Duplicate tables found with the same table-id. The table-id must be unique across all tables.",
-	"tpt-tracking-category": "Pages using progress tables"
+	"tpt-tracking-category": "Pages using progress tables",
+    "tableprogresstracking-error-wikitext-size": "Input wikitext ($1) is larger than allowed ($2)",
+    "tableprogresstracking-error-html-size": "The resultant HTML ($1) is larger than allowed ($2)",
+    "tableprogresstracking-error-parsing-wikitext": "Processing timeout exceeded during wikitext parsing",
+    "tableprogresstracking-error-parsing-html": "Processing timeout exceeded during html parsing",
+    "tableprogresstracking-error-max-columns": "Table has too many columns. Maximum of $1 allowed",
+    "tableprogresstracking-error-max-rows": "Table has too many rows. Maximum of $1 allowed"
 }

--- a/includes/ProgressTableProcessor.php
+++ b/includes/ProgressTableProcessor.php
@@ -117,8 +117,8 @@ class ProgressTableProcessor {
 		$this->maxRows = $config->get( 'TableProgressTrackingMaxRows' );
 
 		// if this wasn't set, then allow us to take 25% of the max article size.
-		// in a default MediaWiki install, where $wgMaxArticleSize is unset, this will be 512KB
-		$this->maxHTMLSize = $config->get( 'TableProgressTrackingMaxHTMLSize' ) ?? ( 0.25 * $maxArticleSize );
+		// in a default MediaWiki install, where $wgMaxArticleSize is unset
+		$this->maxHTMLSize = $config->get( 'TableProgressTrackingMaxHTMLSize' ) ?? (int)( $maxArticleSize * 1024 * 0.25 );
 		$this->maxProcessingTime = $config->get( 'TableProgressTrackingMaxProcessingTime' );
 
 		// maximum bytes of wikitext we will try and parse. We will allow parsing of either 50KB by default


### PR DESCRIPTION
Validate the input size and output size, and constantly monitor how long we have been processing the table for. If we have a table that is too large, or has been processing for too long, it will eat too much memory. 